### PR TITLE
Script Signing Example 12 Update

### DIFF
--- a/Edition-01/Examples/Script Signing/Example 12.ps1
+++ b/Edition-01/Examples/Script Signing/Example 12.ps1
@@ -2,5 +2,5 @@ $Params = @{
     Path = ${Env:ProgramFiles(x86)}
     ChildPath = 'Windows Kits\10\bin\10.0.22000.0\x64\signtool.exe'
 }
-$SignToolPath = Join-Path @$Params
+$SignToolPath = Join-Path @Params
 & $SignToolPath verify /pa C:\test.ps1


### PR DESCRIPTION
A mistake fixed in the 2022-09-20 revision of the book is still present in example 12 here.

This synchronises the example content.