### PR TITLE
Star Wars API Demo - Migrate to static GitHub API

### DIFF
--- a/Edition-01/Starwars-Demo/src/StarWarsData.Complex.Tests.ps1
+++ b/Edition-01/Starwars-Demo/src/StarWarsData.Complex.Tests.ps1
@@ -54,7 +54,7 @@ Describe 'Get-SWPerson' -Tag 'Unit' {
        gender = 'male'
        eyeColour = 'blue'
        homeWorld = 'Tatooine'
-       filmCount = 6 
+       filmCount = 4
     }
     @{
        name = 'mothma'

--- a/Edition-01/Starwars-Demo/src/StarWarsData.ps1
+++ b/Edition-01/Starwars-Demo/src/StarWarsData.ps1
@@ -6,7 +6,7 @@
 
 #Requires -Version 7.0
 
-$swApiUrl = 'https://mc-starwars-data.azurewebsites.net'
+$swApiUrl = 'https://thefreeman193.github.io/mita-swapi'
 function Invoke-StarWarsApi
 {
     param (
@@ -17,7 +17,7 @@ function Invoke-StarWarsApi
         [int] $id = -1 
     )
     try {
-        $suffix = $id -ne -1 ? "?id=$id" : ""
+        $suffix = $id -ne -1 ? "/$id" : ""
         $path = "$($objectType.ToLower())$suffix"
 
         $output = Invoke-RestMethod -Uri "$swApiUrl/api/$path" -Method GET


### PR DESCRIPTION
The existing Star Wars API (<https://mc-starwars-data.azurewebsites.net>) is no longer online and examples from *The AAA Approach* don't function.

This migrates the example code to a static demo API hosted on GitHub (<https://thefreeman193.github.io/mita-swapi>).

Advantages:

+ Very similar dataset to the old API (only 1 change needed in assertions)
+ Static backend and thus very quick
+ No pagination or result wrapping unlike some other SWAPI demos
+ Online and actively maintained
+ Minimal code changes to examples needed

Not to be merged until manuscript changes are published on LeanPub.

Fixes #11